### PR TITLE
pass custom options to zip.generate

### DIFF
--- a/src/zip.js
+++ b/src/zip.js
@@ -7,7 +7,8 @@ module.exports = function(gj, options) {
 
     var zip = new JSZip(),
         options = options || {},
-        layers = zip.folder(options.folder ? options.folder : 'layers');
+        layers = zip.folder(options.folder ? options.folder : 'layers'),
+        zipOpts = {compression: 'STORE'};
 
     [geojson.point(gj), geojson.line(gj), geojson.polygon(gj)]
         .forEach(function(l) {
@@ -29,5 +30,10 @@ module.exports = function(gj, options) {
         }
     });
 
-    return zip.generate({compression:'STORE'});
+
+    for (var k in options.zipOpts) {
+        zipOpts[k] = options.zipOpts[k];
+    }
+
+    return zip.generate(zipOpts);
 };


### PR DESCRIPTION
this allows, for example, to set the type='nodebuffer' when you are
working in nodejs
